### PR TITLE
Add repology badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ FindPython is installable via any kind of package manager including `pip`:
 pip install findpython
 ```
 
+<details>
+<summary>Expand this section to see findpython's availability in the package ecosystem</summary>
+
+<a href="https://repology.org/project/python:findpython/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/python:findpython.svg?header=python%3Afindpython" alt="Packaging status" align="right">
+</a>
+</details>
+
 ## Usage
 
 ```python

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install findpython
 <summary>Expand this section to see findpython's availability in the package ecosystem</summary>
 
 <a href="https://repology.org/project/python:findpython/versions">
-    <img src="https://repology.org/badge/vertical-allrepos/python:findpython.svg?header=python%3Afindpython" alt="Packaging status" align="right">
+    <img src="https://repology.org/badge/vertical-allrepos/python:findpython.svg?header=python%3Afindpython" alt="Packaging status">
 </a>
 </details>
 


### PR DESCRIPTION
Adds a repology badge to the README.md embdded in a hidden div in order to not overwhelm the documentation as the badge grows.  Closes #6

Preview: https://github.com/luzpaz/findpython/blob/repology-badge/README.md#installation