### PR TITLE
Fix #10: prevent find_all exception when a clean pyenv is present

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: >
 
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/src/findpython/providers/pyenv.py
+++ b/src/findpython/providers/pyenv.py
@@ -24,9 +24,11 @@ class PyenvProvider(BaseProvider):
         return cls(Path(pyenv_root))
 
     def find_pythons(self) -> Iterable[PythonVersion]:
-        for version in self.root.joinpath("versions").iterdir():
-            if version.is_dir():
-                bindir = version / "bin"
-                if not bindir.exists():
-                    bindir = version
-                yield from self.find_pythons_from_path(bindir, True)
+        versions_path = self.root.joinpath("versions")
+        if versions_path.exists():
+            for version in versions_path.iterdir():
+                if version.is_dir():
+                    bindir = version / "bin"
+                    if not bindir.exists():
+                        bindir = version
+                    yield from self.find_pythons_from_path(bindir, True)

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -125,3 +125,12 @@ def test_find_python_from_pyenv(mocked_python, tmp_path, monkeypatch):
     pythons = Finder().find_all(3, 8)
     assert len(pythons) == 2
     assert python in pythons
+
+
+def test_find_python_skips_empty_pyenv(mocked_python, tmp_path, monkeypatch):
+    ALL_PROVIDERS.append(PyenvProvider)
+    pyenv_path = Path(tmp_path / ".pyenv")
+    pyenv_path.mkdir()
+    monkeypatch.setenv("PYENV_ROOT", str(pyenv_path))
+    all_pythons = Finder().find_all()
+    assert len(all_pythons) == 3


### PR DESCRIPTION
In case the 'versions' folder does not exist, such as when Pyenv is fhresly installed, Pyenv provider no longer tries to look for a PythonVersion within it.

This PR also includes a bump in black due to being unable to commit:
https://github.com/psf/black/issues/2964