### PR TITLE
fix: check path access before is_dir to prevent PermissionError exceptions

### DIFF
--- a/src/findpython/providers/base.py
+++ b/src/findpython/providers/base.py
@@ -38,7 +38,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
             If the pythons might be a wrapper script, don't set this to True.
         :returns: An iterable of PythonVersion objects
         """
-        if not path.is_dir() or not path_is_readable(path):
+        if not path_is_readable(path) or not path.is_dir():
             logger.debug("Invalid path or unreadable: %s", path)
             return iter([])
         return (


### PR DESCRIPTION
Avoid uncaught `PermissionError`s on WSL1/WSL2 due to the presence of `/mnt/c/Windows/system32/config/systemprofile/AppData/Local/Microsoft/WindowsApps` in the system `PATH`, where `/mnt/c/Windows/system32/config/` is not accessible.

pytests pass.

Example exception before this change:

```
In [1]: import findpython

In [2]: findpython.find()
---------------------------------------------------------------------------
PermissionError                           Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 findpython.find()

File ~/.local/lib/python3.10/site-packages/findpython/__init__.py:25, in find(*args, **kwargs)
     12 def find(*args, **kwargs) -> PythonVersion | None:
     13     """
     14     Return the Python version that is closest to the given version criteria.
     15
   (...)
     23     :return: a Python object or None
     24     """
---> 25     return Finder().find(*args, **kwargs)

File ~/.local/lib/python3.10/site-packages/findpython/finder.py:129, in Finder.find(self, major, minor, patch, pre, dev, name, architecture)
    106 def find(
    107     self,
    108     major: int | str | None = None,
   (...)
    114     architecture: str | None = None,
    115 ) -> PythonVersion | None:
    116     """
    117     Return the Python version that is closest to the given version criteria.
    118
   (...)
    126     :return: a Python object or None
    127     """
    128     return next(
--> 129         iter(self.find_all(major, minor, patch, pre, dev, name, architecture)),
    130         None,
    131     )

File ~/.local/lib/python3.10/site-packages/findpython/finder.py:103, in Finder.find_all(self, major, minor, patch, pre, dev, name, architecture)
     92 version_matcher = operator.methodcaller(
     93     "matches",
     94     major,
   (...)
    100     architecture,
    101 )
    102 # Deduplicate with the python executable path
--> 103 matched_python = set(self._find_all_python_versions())
    104 return self._dedup(matched_python, version_matcher)

File ~/.local/lib/python3.10/site-packages/findpython/finder.py:136, in Finder._find_all_python_versions(self)
    134 """Find all python versions on the system."""
    135 for provider in self._providers:
--> 136     yield from provider.find_pythons()

File ~/.local/lib/python3.10/site-packages/findpython/providers/path.py:25, in PathProvider.find_pythons(self)
     23 def find_pythons(self) -> Iterable[PythonVersion]:
     24     for path in self.paths:
---> 25         yield from self.find_pythons_from_path(path)

File ~/.local/lib/python3.10/site-packages/findpython/providers/base.py:41, in BaseProvider.find_pythons_from_path(cls, path, as_interpreter)
     30 @classmethod
     31 def find_pythons_from_path(
     32     cls, path: Path, as_interpreter: bool = False
     33 ) -> Iterable[PythonVersion]:
     34     """A general helper method to return pythons under a given path.
     35
     36     :param path: The path to search for pythons
   (...)
     39     :returns: An iterable of PythonVersion objects
     40     """
---> 41     if not path.is_dir() or not path_is_readable(path):
     42         logger.debug("Invalid path or unreadable: %s", path)
     43         return iter([])

File /usr/lib/python3.10/pathlib.py:1305, in Path.is_dir(self)
   1301 """
   1302 Whether this path is a directory.
   1303 """
   1304 try:
-> 1305     return S_ISDIR(self.stat().st_mode)
   1306 except OSError as e:
   1307     if not _ignore_error(e):

File /usr/lib/python3.10/pathlib.py:1097, in Path.stat(self, follow_symlinks)
   1092 def stat(self, *, follow_symlinks=True):
   1093     """
   1094     Return the result of the stat() system call on this path, like
   1095     os.stat() does.
   1096     """
-> 1097     return self._accessor.stat(self, follow_symlinks=follow_symlinks)

PermissionError: [Errno 13] Permission denied: '/mnt/c/Windows/system32/config/systemprofile/AppData/Local/Microsoft/WindowsApps'
```