### PR TITLE
Fix UTF-8 encoding of shell command output on Windows

### DIFF
--- a/src/findpython/python.py
+++ b/src/findpython/python.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 from functools import lru_cache
 from pathlib import Path
+import os
 
 from packaging.version import InvalidVersion, Version
 
@@ -181,9 +182,11 @@ class PythonVersion:
         """Run a script and return the output."""
         command = [self.executable.as_posix(), "-c", script]
         logger.debug("Running script: %s", command)
+        os.environ["PYTHONIOENCODING"] = "utf-8"
         return subprocess.check_output(
-            command, input=None, stderr=subprocess.DEVNULL, timeout=timeout
-        ).decode("utf-8")
+            command, input=None, stderr=subprocess.DEVNULL, timeout=timeout,
+            encoding="utf-8"
+        )
 
     def __lt__(self, other: PythonVersion) -> bool:
         """Sort by the version, then by length of the executable path."""

--- a/src/findpython/python.py
+++ b/src/findpython/python.py
@@ -5,7 +5,6 @@ import logging
 import subprocess
 from functools import lru_cache
 from pathlib import Path
-import os
 
 from packaging.version import InvalidVersion, Version
 
@@ -182,10 +181,9 @@ class PythonVersion:
         """Run a script and return the output."""
         command = [self.executable.as_posix(), "-c", script]
         logger.debug("Running script: %s", command)
-        os.environ["PYTHONIOENCODING"] = "utf-8"
         return subprocess.check_output(
             command, input=None, stderr=subprocess.DEVNULL, timeout=timeout,
-            encoding="utf-8"
+            text=True
         )
 
     def __lt__(self, other: PythonVersion) -> bool:


### PR DESCRIPTION
On Windows, when running pdm from the command line, it would fail when special characters are in the python path (such as "ä", "ö", "ß"). The fix was implemented as described here: https://stackoverflow.com/a/74607949