### PR TITLE
Add way to filter providers

### DIFF
--- a/src/findpython/__main__.py
+++ b/src/findpython/__main__.py
@@ -46,6 +46,11 @@ def cli(argv: List[str] | None = None) -> int:
         action="store_true",
         help="Eliminate the duplicated results with the same sys.executable",
     )
+    parser.add_argument(
+        "--provider",
+        nargs="+",
+        help="Select provider(s) to use",
+    )
     parser.add_argument("version_spec", nargs="?", help="Python version spec or name")
 
     args = parser.parse_args(argv)
@@ -56,7 +61,8 @@ def cli(argv: List[str] | None = None) -> int:
         find_func = finder.find_all
     else:
         find_func = finder.find
-    python_versions = find_func(args.version_spec)
+
+    python_versions = find_func(args.version_spec, from_provider=args.provider)
     if not python_versions:
         print("No matching python version found", file=sys.stderr)
         return 1

--- a/src/findpython/providers/base.py
+++ b/src/findpython/providers/base.py
@@ -18,6 +18,17 @@ class BaseProvider(metaclass=abc.ABCMeta):
     version_maker: Callable[..., PythonVersion] = PythonVersion
 
     @classmethod
+    def name(cls) -> str:
+        """Configuration name for this provider.
+
+        By default, the lowercase class name with 'provider' removed.
+        """
+        self_name = cls.__name__.lower()
+        if self_name.endswith("provider"):
+            self_name = self_name[:-len("provider")]
+        return self_name
+
+    @classmethod
     @abc.abstractmethod
     def create(cls: Type[T]) -> T | None:
         """Return an instance of the provider or None if it is not available"""

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -7,6 +7,7 @@ import pytest
 from findpython.finder import Finder
 from findpython.providers import ALL_PROVIDERS
 from findpython.providers.asdf import AsdfProvider
+from findpython.providers.pyenv import PyenvProvider
 
 if sys.platform == "win32":
     pytest.skip("Skip POSIX tests on Windows", allow_module_level=True)
@@ -43,3 +44,34 @@ def test_find_python_exclude_unreadable(mocked_python, tmp_path):
         assert python not in [version.executable for version in all_pythons]
     finally:
         python.chmod(0o744)
+
+
+def test_find_python_from_provider(mocked_python, tmp_path, monkeypatch):
+    ALL_PROVIDERS.append(AsdfProvider)
+    ALL_PROVIDERS.append(PyenvProvider)
+    python38 = mocked_python.add_python(
+        tmp_path / ".asdf/installs/python/3.8/bin/python", "3.8.0"
+    )
+    python381 = mocked_python.add_python(
+        tmp_path / ".pyenv/versions/3.8.1/bin/python", "3.8.1"
+    )
+    python382 = mocked_python.add_python(
+        tmp_path / ".asdf/installs/python/3.8.2/bin/python", "3.8.2"
+    )
+    monkeypatch.setenv("ASDF_DATA_DIR", str(tmp_path / ".asdf"))
+    monkeypatch.setenv("PYENV_ROOT", str(tmp_path / ".pyenv"))
+
+    pythons = Finder().find_all(3, 8, from_provider=["pyenv", "asdf"])
+    assert len(pythons) == 3
+    assert python38 in pythons
+    assert python381 in pythons
+    assert python382 in pythons
+
+    asdf_pythons = Finder().find_all(3, 8, from_provider=["asdf"])
+    assert len(asdf_pythons) == 2
+    assert python38 in asdf_pythons
+    assert python382 in asdf_pythons
+
+    pyenv_pythons = Finder().find_all(3, 8, from_provider=["pyenv"])
+    assert len(pyenv_pythons) == 1
+    assert python381 in pyenv_pythons


### PR DESCRIPTION
Each provider needs to have a name for configuration, i.e PathProvider has 'path'.
Here using a classmethod since class properties are deprecated.

The intention is that the caller can choose a particular provider or providers to
allow for finding python.