### PR TITLE
Make GET_VERSION_TIMEOUT settable via env vars

### DIFF
--- a/src/findpython/python.py
+++ b/src/findpython/python.py
@@ -12,12 +12,7 @@ from packaging.version import InvalidVersion, Version
 from findpython.utils import get_binary_hash
 
 logger = logging.getLogger("findpython")
-_DEFAULT_GET_VERSION_TIMEOUT = 5
-
-
-def get_version_timeout() -> float:
-    """Return the timeout for getting a Python version."""
-    return float(os.environ.get("FINDPYTHON_GET_VERSION_TIMEOUT", _DEFAULT_GET_VERSION_TIMEOUT))
+GET_VERSION_TIMEOUT = float(os.environ.get("FINDPYTHON_GET_VERSION_TIMEOUT", 5))
 
 
 @lru_cache(maxsize=1024)
@@ -183,7 +178,7 @@ class PythonVersion:
         """Get the version of the python."""
         script = "import platform; print(platform.python_version())"
         version = _run_script(
-            str(self.executable), script, timeout=get_version_timeout(),
+            str(self.executable), script, timeout=GET_VERSION_TIMEOUT,
         ).strip()
         # Dev builds may produce version like `3.11.0+` and packaging.version
         # will reject it. Here we just remove the part after `+`

--- a/src/findpython/python.py
+++ b/src/findpython/python.py
@@ -178,7 +178,7 @@ class PythonVersion:
         """Get the version of the python."""
         script = "import platform; print(platform.python_version())"
         version = _run_script(
-            str(self.executable), script, timeout=GET_VERSION_TIMEOUT,
+            str(self.executable), script, timeout=GET_VERSION_TIMEOUT
         ).strip()
         # Dev builds may produce version like `3.11.0+` and packaging.version
         # will reject it. Here we just remove the part after `+`

--- a/src/findpython/python.py
+++ b/src/findpython/python.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses as dc
 import logging
+import os
 import subprocess
 from functools import lru_cache
 from pathlib import Path
@@ -11,7 +12,12 @@ from packaging.version import InvalidVersion, Version
 from findpython.utils import get_binary_hash
 
 logger = logging.getLogger("findpython")
-GET_VERSION_TIMEOUT = 5
+_DEFAULT_GET_VERSION_TIMEOUT = 5
+
+
+def get_version_timeout() -> float:
+    """Return the timeout for getting a Python version."""
+    return float(os.environ.get("FINDPYTHON_GET_VERSION_TIMEOUT", _DEFAULT_GET_VERSION_TIMEOUT))
 
 
 @lru_cache(maxsize=1024)
@@ -177,7 +183,7 @@ class PythonVersion:
         """Get the version of the python."""
         script = "import platform; print(platform.python_version())"
         version = _run_script(
-            str(self.executable), script, timeout=GET_VERSION_TIMEOUT
+            str(self.executable), script, timeout=get_version_timeout(),
         ).strip()
         # Dev builds may produce version like `3.11.0+` and packaging.version
         # will reject it. Here we just remove the part after `+`


### PR DESCRIPTION
I found that some interpreters, in particular, PyPy, can be so slow to start up under resource-constrained environments (in particular GitHub Actions runners) that 5s is not enough.

Instead of just making it 30s we can make it settable by env vars so that most users can fail fast but we can set it higher in CI.