### PR TITLE
Find rye pythons with and without install directory

### DIFF
--- a/src/findpython/providers/rye.py
+++ b/src/findpython/providers/rye.py
@@ -25,9 +25,11 @@ class RyeProvider(BaseProvider):
         for child in safe_iter_dir(py_root):
             if child.is_symlink():  # registered an existing python
                 continue
-            if WINDOWS:
-                python_bin = child / "install/python.exe"
-            else:
-                python_bin = child / "install/bin/python3"
-            if python_bin.exists():
-                yield self.version_maker(python_bin, _interpreter=python_bin)
+            for intermediate in ("", "install/"):
+                if WINDOWS:
+                    python_bin = child / (intermediate + "python.exe")
+                else:
+                    python_bin = child / (intermediate + "bin/python3")
+                if python_bin.exists():
+                    yield self.version_maker(python_bin, _interpreter=python_bin)
+                    break

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -82,8 +82,14 @@ def test_find_python_from_rye_provider(mocked_python, tmp_path, monkeypatch):
     python310 = mocked_python.add_python(
         tmp_path / ".rye/py/cpython@3.10.9/install/bin/python3", "3.10.9"
     )
+    python311 = mocked_python.add_python(
+        tmp_path / ".rye/py/cpython@3.11.8/bin/python3", "3.11.8"
+    )
     monkeypatch.setenv("HOME", str(tmp_path))
 
     register_provider(RyeProvider)
-    pythons = Finder(selected_providers=["rye"]).find_all(3, 10)
-    assert python310 in pythons
+    find_310 = Finder(selected_providers=["rye"]).find_all(3, 10)
+    assert python310 in find_310
+
+    find_311 = Finder(selected_providers=["rye"]).find_all(3, 11)
+    assert python311 in find_311


### PR DESCRIPTION
Starting with rye 0.31 (released today), it by default installs python toolchains without the intermediate install directory (but both options continue to exist).

As a side effect, this also picks up some other rye toolchains that were already installed without the intermediate install - for example pypy toolchains installed with rye.